### PR TITLE
Mark all registers as transparent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use core::cell::UnsafeCell;
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct RWRegister<T> {
     register: UnsafeCell<T>,
 }
@@ -51,6 +52,7 @@ impl<T: Copy> RWRegister<T> {
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct UnsafeRWRegister<T> {
     register: UnsafeCell<T>,
 }
@@ -85,6 +87,7 @@ impl<T: Copy> UnsafeRWRegister<T> {
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct RORegister<T> {
     register: UnsafeCell<T>,
 }
@@ -107,6 +110,7 @@ impl<T: Copy> RORegister<T> {
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct UnsafeRORegister<T> {
     register: UnsafeCell<T>,
 }
@@ -132,6 +136,7 @@ impl<T: Copy> UnsafeRORegister<T> {
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct WORegister<T> {
     register: UnsafeCell<T>,
 }
@@ -154,6 +159,7 @@ impl<T: Copy> WORegister<T> {
 ///
 /// Access to this register must be synchronised; if multiple threads (or the main thread and an
 /// interrupt service routine) are accessing it simultaneously you may encounter data races.
+#[repr(transparent)]
 pub struct UnsafeWORegister<T> {
     register: UnsafeCell<T>,
 }


### PR DESCRIPTION
Guarantees that the layout is the same as the inner type. Since
UnsafeCell is also transparent, this ensures that the register has the
same ABI as T.

Today's registers work without this. Otherwise, RAL register blocks
would have unaccounted offsets / wrong sizes. This is for completness,
and a signal for others that a transmute might be OK.  Requires Rust
1.28.